### PR TITLE
Feature sha256 on deploy and fix docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
   docs:
     needs: version
-    uses: noveto-com/shared-workflows/.github/workflows/docs.yml@feature/sha256
+    uses: noveto-com/shared-workflows/.github/workflows/docs.yml@874dae19b7bcbe5f6a2621b098082f8fa38a300f
     with:
       version: ${{ needs.version.outputs.version }}
       pdf-name: "sharedworkflows.pdf"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
   docs:
     needs: version
-    uses: noveto-com/shared-workflows/.github/workflows/docs.yml@develop
+    uses: noveto-com/shared-workflows/.github/workflows/docs.yml@feature/sha256
     with:
       version: ${{ needs.version.outputs.version }}
       pdf-name: "sharedworkflows.pdf"

--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -40,7 +40,7 @@ jobs:
           path: artifacts
 
       - name: Upload to S3
-        uses: jakejarvis/s3-sync-action@master
+        uses: noveto-com/s3-upload-sha256-action@develop
         with:
           args:
         env:

--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -40,7 +40,7 @@ jobs:
           path: artifacts
 
       - name: Upload to S3
-        uses: noveto-com/s3-upload-sha256-action@develop
+        uses: noveto-com/s3-upload-sha256-action@v0.0.1
         with:
           args:
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install Sphinx==3.5.4 myst-parser==0.15.2
       - name: Install additional packages for documentation building
-        run: sudo apt-get install -y texlive texlive-latex-extra latexmk
+        run: |
+          sudo apt-get update && sudo apt-get install -y \
+            texlive=2019.20200218-1 \
+            texlive-latex-extra=2019.202000218-1 \
+            latexmk=1:4.67-0.1
       - name: Save Version
         run:  echo ${{ inputs.version }} > .version
       - name: Build documentation


### PR DESCRIPTION
Changes:
1. Use new noveto-com/s3-upload-sha256-action for deploy
2. Fix broken docs workflow