### PR TITLE
feature: add PEP440 compliant version for python

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -9,6 +9,9 @@ on:
       tag:
         description: "The new tag if any"
         value: ${{ jobs.prepare-release.outputs.tag }}
+      pep440:
+        description: "The PEP440 compatible version for python packages"
+        value: ${{ jobs.prepare-release.outputs.pep440 }}
 
 jobs:
   prepare-release:
@@ -85,14 +88,18 @@ jobs:
         run: |
           TAG_VERSION_NUMBER=$(git describe --tags --dirty)
           echo "VERSION_NUMBER=${TAG_VERSION_NUMBER:1}" >> $GITHUB_ENV
+          PEP440=$(git describe --tags --dirty | sed -e 's/v//' | sed -e 's/-/.dev/' | sed -e 's/-g.*//')
+          echo "PEP440_VERSION_NUMBER=${PEP440}" >> $GITHUB_ENV
         shell: bash
 
       - name: Display outputs
         run: |
           echo "Version is ${{ env.VERSION_NUMBER }}"
           echo "TAG is ${{ env.NEW_TAG }}"
+          echo "PEP440 is ${{ env.PEP440_VERSION_NUMBER }}"
         shell: bash
 
     outputs:
       version: ${{ env.VERSION_NUMBER }}
       tag: ${{ env.NEW_TAG }}
+      pep440: ${{ env.PEP440_VERSION_NUMBER }}

--- a/docs/version.md
+++ b/docs/version.md
@@ -29,9 +29,11 @@ It will do the following:
    2. For a normal build this will be something like:
       1. version: `1.0.2-4-g66f9fca`
       2. tag: `v1.0.2-4-g66f9fca`
+      3. pep440: `1.0.2.dev4`
    3. For a release build this will be the new version/tag, something like:
       1. version: `1.0.3`
       2. tag: `v1.0.3`
+      3. pep440: `1.0.3`
 
 Example:
 


### PR DESCRIPTION
Python does not support the git describe format for python module versions. 
See [PEP440](https://peps.python.org/pep-0440/).

This change provides an additional `pep440` output with a version compatible with PEP440 for python code.