### PR TITLE
ci: update actions to version with Node.js 20

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Get all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 

--- a/.github/workflows/deploy-s3.yml
+++ b/.github/workflows/deploy-s3.yml
@@ -35,7 +35,7 @@ jobs:
         run: echo "${{ inputs.version }}"
 
       - name: Get all artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           path: artifacts
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,9 +25,9 @@ jobs:
   build-documentation:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8.10
       - name: Install dependencies
@@ -49,11 +49,11 @@ jobs:
         run: |
           make -C ${{ inputs.docs-folder }} html
           make -C ${{ inputs.docs-folder }} latexpdf
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: documentationHTML
           path: docs/_build/html/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: documentation
           path: "docs/_build/latex/${{ inputs.pdf-name }}"       

--- a/.github/workflows/kicad-release.yml
+++ b/.github/workflows/kicad-release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           lfs: true
   
@@ -69,25 +69,25 @@ jobs:
           NAME: ${{ inputs.name }}
 
       - name: Save artifact (all outputs)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: output-${{ inputs.version }}
           path: output
   
       - name: Save artifact (BOM)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.name }}-bom-${{ inputs.version }}
           path: ${{ inputs.name }}-bom-${{ inputs.version }}.csv
 
       - name: Save artifact (Schematic)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.name }}-schematic-${{ inputs.version }}
           path: ${{ inputs.name }}-schematic-${{ inputs.version }}.pdf
 
       - name: Save artifact (Project)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.name }}-${{ inputs.version }}
           path: ${{ inputs.name }}-${{ inputs.version }}.tar.gz

--- a/.github/workflows/kicad-version.yml
+++ b/.github/workflows/kicad-version.yml
@@ -16,7 +16,7 @@ jobs:
     kicad-version:
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
 
         - name: Strip v from TAG
           run: |

--- a/.github/workflows/rust-version.yml
+++ b/.github/workflows/rust-version.yml
@@ -16,7 +16,7 @@ jobs:
     rust-version:
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
 
         - name: Strip v from TAG
           run: |

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -79,7 +79,7 @@ jobs:
           echo "NEW_TAG=${{ steps.version-main.outputs.new_tag }}" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get tags
         run: git fetch --prune --unshallow --tags


### PR DESCRIPTION
- checkout v4 uses Node.js 20 instead of deprecated 16
- upload/download-artifact v4
- setup-python v5